### PR TITLE
quick fix such that actions should run in main repo instead of fork on pull request

### DIFF
--- a/.github/workflows/junitTest.yml
+++ b/.github/workflows/junitTest.yml
@@ -1,7 +1,6 @@
 name: tests
 on:
   pull_request_target:
-    types: [opened, edited]
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/junitTest.yml
+++ b/.github/workflows/junitTest.yml
@@ -1,6 +1,7 @@
 name: tests
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, edited]
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
This should fix the issue of the forks not being able to create the .serect.txt file. Technically this is less secure, so the API KEY should be a burner.