### PR TITLE
DefaultView refactor/bugfix + Make MovieInfo use case work from Watchlist / Rating views

### DIFF
--- a/src/app/GetRatingsUseCaseFactory.java
+++ b/src/app/GetRatingsUseCaseFactory.java
@@ -1,14 +1,13 @@
 package app;
 
-import data_access.UserRatingAccessObject;
 import interface_adapters.ViewManagerModel;
 import interface_adapters.get_ratings.GetRatingsController;
 import interface_adapters.get_ratings.GetRatingsPresenter;
 import interface_adapters.get_ratings.GetRatingsViewModel;
-import interface_adapters.movie_info.MovieInfoViewModel;
 import use_case.get_ratings.*;
 import use_case.get_watchlist.GetWatchlistDataAccessInterface;
 import utility.ApiInterface;
+import view.MovieInfoView;
 import view.RatingsView;
 
 public class GetRatingsUseCaseFactory {
@@ -20,9 +19,9 @@ public class GetRatingsUseCaseFactory {
     public static RatingsView create(ApiInterface api, GetRatingsViewModel getRatingsViewModel, ViewManagerModel viewManagerModel,
                                        GetRatingsDataAccessInterface ratingsDataAccessObject,
                                        GetWatchlistDataAccessInterface watchlistAccessObject,
-                                       MovieInfoViewModel movieInfoViewModel) {
+                                       MovieInfoView movieInfoView) {
         GetRatingsController getRatingsController = createGetRatingsUseCase(getRatingsViewModel, viewManagerModel, ratingsDataAccessObject, watchlistAccessObject, api);
-        return new RatingsView(getRatingsController, MovieInfoUseCaseFactory.createMovieInfoUseCase(api, movieInfoViewModel), getRatingsViewModel);
+        return new RatingsView(getRatingsController, getRatingsViewModel, movieInfoView);
     }
 
     public static GetRatingsController createGetRatingsUseCase(GetRatingsViewModel getRatingsViewModel, ViewManagerModel viewManagerModel, GetRatingsDataAccessInterface ratingsDataAccessObject,

--- a/src/app/GetWatchlistUseCaseFactory.java
+++ b/src/app/GetWatchlistUseCaseFactory.java
@@ -8,6 +8,7 @@ import interface_adapters.get_watchlist.GetWatchlistViewModel;
 import interface_adapters.movie_info.MovieInfoViewModel;
 import use_case.get_watchlist.*;
 import utility.ApiInterface;
+import view.MovieInfoView;
 import view.WatchlistView;
 
 public class GetWatchlistUseCaseFactory {
@@ -18,9 +19,9 @@ public class GetWatchlistUseCaseFactory {
 
     public static WatchlistView create(ApiInterface api, GetWatchlistViewModel getWatchlistViewModel, ViewManagerModel viewManagerModel,
                                        GetWatchlistDataAccessInterface watchlistDataAccessObject, UserRatingAccessObject ratingAccessObject,
-                                       MovieInfoViewModel movieInfoViewModel) {
+                                       MovieInfoView movieInfoView) {
         GetWatchlistController getWatchlistController = createGetWatchlistUseCase(getWatchlistViewModel, viewManagerModel, watchlistDataAccessObject, ratingAccessObject, api);
-        return new WatchlistView(getWatchlistController, MovieInfoUseCaseFactory.createMovieInfoUseCase(api, movieInfoViewModel), getWatchlistViewModel);
+        return new WatchlistView(getWatchlistController, getWatchlistViewModel, movieInfoView);
     }
 
     public static GetWatchlistController createGetWatchlistUseCase(GetWatchlistViewModel getWatchlistViewModel, ViewManagerModel viewManagerModel, GetWatchlistDataAccessInterface getWatchlistAccessObject,

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -63,11 +63,11 @@ public class Main {
         LoginView loginView = LoginUseCaseFactory.create(viewManagerModel, loginViewModel, loggedInViewModel, userDataAccessObject);
         views.add(loginView, loginView.viewName);
 
-        WatchlistView watchlistView = GetWatchlistUseCaseFactory.create(api, getWatchlistViewModel, viewManagerModel, watchlistAccessObject, ratingAccessObject, movieInfoViewModel);
-        RatingsView ratingsView = GetRatingsUseCaseFactory.create(api, getRatingsViewModel, viewManagerModel, ratingAccessObject, watchlistAccessObject, movieInfoViewModel);
-        MovieInfoController movieInfoController = MovieInfoUseCaseFactory.createMovieInfoUseCase(api, movieInfoViewModel);
+        MovieInfoView movieInfoView = MovieInfoUseCaseFactory.create(api, movieInfoViewModel);
+        WatchlistView watchlistView = GetWatchlistUseCaseFactory.create(api, getWatchlistViewModel, viewManagerModel, watchlistAccessObject, ratingAccessObject, movieInfoView);
+        RatingsView ratingsView = GetRatingsUseCaseFactory.create(api, getRatingsViewModel, viewManagerModel, ratingAccessObject, watchlistAccessObject, movieInfoView);
 
-        LoggedInView loggedInView = new LoggedInView(loggedInViewModel, watchlistView, ratingsView, movieInfoController);
+        LoggedInView loggedInView = new LoggedInView(loggedInViewModel, watchlistView, ratingsView);
         views.add(loggedInView, loggedInView.viewName);
 
         viewManagerModel.setActiveView(signupView.viewName);

--- a/src/app/MovieInfoUseCaseFactory.java
+++ b/src/app/MovieInfoUseCaseFactory.java
@@ -19,7 +19,7 @@ public class MovieInfoUseCaseFactory {
         return new MovieInfoView(controller, viewmodel);
     }
 
-    public static MovieInfoController createMovieInfoUseCase(ApiInterface api, MovieInfoViewModel viewmodel) {
+    private static MovieInfoController createMovieInfoUseCase(ApiInterface api, MovieInfoViewModel viewmodel) {
         MovieInfoOutputBoundary movieInfoPresenter = new MovieInfoPresenter(viewmodel);
         MovieInfoInputBoundary movieInfoInteractor = new MovieInfoInteractor(api, movieInfoPresenter);
         return new MovieInfoController(movieInfoInteractor);

--- a/src/view/DefaultView.java
+++ b/src/view/DefaultView.java
@@ -4,7 +4,6 @@ import entity.Movie;
 import entity.UserRating;
 import interface_adapters.get_watchlist.GetWatchlistController;
 import interface_adapters.get_watchlist.GetWatchlistViewModel;
-import interface_adapters.movie_info.MovieInfoController;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -20,27 +19,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class DefaultView extends JPanel {
-    private GetWatchlistController getWatchlistController;
-    private MovieInfoController movieInfoController;
-    private GetWatchlistViewModel getWatchlistViewModel;
+    protected MovieInfoView movieInfoView;
     private final Dimension DIMENSIONS = new Dimension(350,275);
     private java.util.List<Movie> movieList;
     private List<UserRating> ratings;
     private JScrollPane scrollPane;
     private JPanel panelList;
     private String user;
-
-    public void createWatchlistPanel() {;
-        setLayout(new BorderLayout());
-
-        // Create a scroll pane to hold the panel list
-        movieList = getWatchlistViewModel.getState().getMovieList();
-        ratings = getWatchlistViewModel.getState().getRatings();
-        scrollPane = new JScrollPane(createPanelList(movieList, ratings));
-        scrollPane.setPreferredSize(DIMENSIONS);
-
-        add(scrollPane, BorderLayout.CENTER);
-    }
 
     public JPanel createPanelList(List<Movie> movieList, List<UserRating> ratings) {
         panelList = new JPanel(); // Initialize the panelList field
@@ -132,7 +117,7 @@ public abstract class DefaultView extends JPanel {
             @Override
             public void mouseClicked(MouseEvent e) {
                 //PLACEHOLDER - to be replaced with showing the information pane of the movie
-                movieInfoController.execute(movie.getImdbID());
+                movieInfoView.showMovie(movie.getImdbID());
             }
         });
 

--- a/src/view/LoggedInView.java
+++ b/src/view/LoggedInView.java
@@ -22,8 +22,6 @@ public class LoggedInView extends DefaultView implements ActionListener, Propert
     private final LoggedInViewModel loggedInViewModel;
     private final WatchlistView watchlistView;
     private final RatingsView ratingsView;
-
-    private final MovieInfoController movieInfoController;
     private List<Movie> movieList;
     private List<UserRating> ratings;
     private JScrollPane scrollPane;
@@ -48,11 +46,10 @@ public class LoggedInView extends DefaultView implements ActionListener, Propert
     /**
      * A window with a title and a JButton.
      */
-    public LoggedInView(LoggedInViewModel loggedInViewModel, WatchlistView watchlistView, RatingsView ratingsView, MovieInfoController movieInfoController) {
+    public LoggedInView(LoggedInViewModel loggedInViewModel, WatchlistView watchlistView, RatingsView ratingsView) {
         this.loggedInViewModel = loggedInViewModel;
         this.watchlistView = watchlistView;
         this.ratingsView = ratingsView;
-        this.movieInfoController = movieInfoController;
         this.loggedInViewModel.addPropertyChangeListener(this);
         setLayout(new BorderLayout());
 

--- a/src/view/RatingsView.java
+++ b/src/view/RatingsView.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 public class RatingsView extends DefaultView implements PropertyChangeListener {
     private final GetRatingsController getRatingsController;
-    private final MovieInfoController movieInfoController;
     private final GetRatingsViewModel getRatingsViewModel;
     private final Dimension DIMENSIONS = new Dimension(350,275);
     private List<Movie> movieList;
@@ -24,10 +23,10 @@ public class RatingsView extends DefaultView implements PropertyChangeListener {
     private JPanel panelList;
 
 
-    public RatingsView(GetRatingsController getRatingsController, MovieInfoController movieInfoController, GetRatingsViewModel getRatingsViewModel) {
+    public RatingsView(GetRatingsController getRatingsController, GetRatingsViewModel getRatingsViewModel, MovieInfoView movieInfoView) {
         this.getRatingsController = getRatingsController;
-        this.movieInfoController = movieInfoController;
         this.getRatingsViewModel = getRatingsViewModel;
+        this.movieInfoView = movieInfoView;
         getRatingsViewModel.addPropertyChangeListener(this);
     }
 

--- a/src/view/WatchlistView.java
+++ b/src/view/WatchlistView.java
@@ -5,7 +5,6 @@ import entity.UserRating;
 import interface_adapters.get_watchlist.GetWatchlistController;
 import interface_adapters.get_watchlist.GetWatchlistState;
 import interface_adapters.get_watchlist.GetWatchlistViewModel;
-import interface_adapters.movie_info.MovieInfoController;
 
 import javax.swing.*;
 import java.awt.*;
@@ -14,18 +13,17 @@ import java.beans.PropertyChangeListener;
 import java.util.List;
 
 public class WatchlistView extends DefaultView implements PropertyChangeListener {
-    private final GetWatchlistController getWatchlistController;
-    private final MovieInfoController movieInfoController;
-    private final GetWatchlistViewModel getWatchlistViewModel;
+    private GetWatchlistController getWatchlistController;
+    private GetWatchlistViewModel getWatchlistViewModel;
     private final Dimension DIMENSIONS = new Dimension(350,275);
     private List<Movie> movieList;
     private List<UserRating> ratings;
     private JScrollPane scrollPane;
     private JPanel panelList;
 
-    public WatchlistView(GetWatchlistController getWatchlistController, MovieInfoController movieInfoController, GetWatchlistViewModel getWatchlistViewModel) {
+    public WatchlistView(GetWatchlistController getWatchlistController, GetWatchlistViewModel getWatchlistViewModel, MovieInfoView movieInfoView) {
         this.getWatchlistController = getWatchlistController;
-        this.movieInfoController = movieInfoController;
+        this.movieInfoView = movieInfoView;
         this.getWatchlistViewModel = getWatchlistViewModel;
         getWatchlistViewModel.addPropertyChangeListener(this);
     }
@@ -59,14 +57,11 @@ public class WatchlistView extends DefaultView implements PropertyChangeListener
     private void UpdateView(GetWatchlistState state) {
         this.movieList = state.getMovieList();
         this.ratings = state.getRatings();
-
-
     }
 
     public void showWatchlist(String user) {
         getWatchlistController.execute(user);
     }
-
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {


### PR DESCRIPTION
DefaultView has private fields for WatchListController, WatchListViewModel, and MovieInfoController. However, since DefaultView is abstract and does not have a constructor, these fields are never assigned and thus are always null. Additionally, because they are marked as private they cannot be accessed by subclasses (such as WatchlistView), so WatchlistView declares its own WatchListController / ViewModel fields instead of using the ones in DefaultView. To fix this issue I removed the unused WatchlistController and WatchlistViewModel objects from DefaultView along with the createWatchlistPanel() method as it is already overridden in WatchlistView. I made MovieInfoView protected instead of removing it so that subclasses like WatchlistView can set it in their constructor, and then the mouseClicked() method in DefaultView will no longer give a NullPointer exception.

I also changed the UseCaseFactories to use MovieInfoView instead of MovieInfoViewModel, as previously they were creating a new MovieInfoController each time that had no view associated with it so the popup couldn't be created. With this change the MovieInfo popup works when clicking on movies in the Watchlist and Ratings views.